### PR TITLE
Validate image_url payload for /rate endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,88 @@ interface Stats {
   started_at: string;
 }
 
+interface ValidationIssue {
+  field: string;
+  code: string;
+  message: string;
+}
+
+interface ValidationResult {
+  value?: { image_url: string };
+  issues?: ValidationIssue[];
+}
+
+const MAX_IMAGE_URL_LENGTH = 2_048;
+
+function validateRateRequest(body: unknown): ValidationResult {
+  const issues: ValidationIssue[] = [];
+
+  if (!body || typeof body !== "object") {
+    return {
+      issues: [
+        {
+          field: "body",
+          code: "invalid_type",
+          message: "Request body must be a JSON object",
+        },
+      ],
+    };
+  }
+
+  const imageUrlValue = (body as { image_url?: unknown }).image_url;
+
+  if (typeof imageUrlValue !== "string") {
+    issues.push({
+      field: "image_url",
+      code: "invalid_type",
+      message: "image_url must be a string",
+    });
+    return { issues };
+  }
+
+  const imageUrl = imageUrlValue.trim();
+  if (imageUrl.length === 0) {
+    issues.push({
+      field: "image_url",
+      code: "empty_value",
+      message: "image_url cannot be empty",
+    });
+  }
+
+  if (imageUrl.length > MAX_IMAGE_URL_LENGTH) {
+    issues.push({
+      field: "image_url",
+      code: "too_long",
+      message: `image_url must be <= ${MAX_IMAGE_URL_LENGTH} characters`,
+    });
+  }
+
+  let parsedUrl: URL | undefined;
+  try {
+    parsedUrl = new URL(imageUrl);
+  } catch {
+    issues.push({
+      field: "image_url",
+      code: "invalid_url",
+      message: "image_url must be a valid URL",
+    });
+  }
+
+  if (parsedUrl && !["http:", "https:"].includes(parsedUrl.protocol)) {
+    issues.push({
+      field: "image_url",
+      code: "invalid_protocol",
+      message: "image_url must use http: or https:",
+    });
+  }
+
+  if (issues.length > 0) {
+    return { issues };
+  }
+
+  return { value: { image_url: imageUrl } };
+}
+
 export function createServer(config: AgentConfig) {
   const app = express();
   app.use(express.json());
@@ -46,14 +128,18 @@ export function createServer(config: AgentConfig) {
   app.post("/rate", async (req: Request, res: Response) => {
     stats.requests_total++;
 
-    const { image_url } = req.body as { image_url?: string };
-    if (!image_url) {
+    const validation = validateRateRequest(req.body);
+    if (!validation.value) {
       stats.requests_failed++;
-      res.status(400).json({ error: "Missing required field: image_url" });
+      res.status(400).json({
+        error: "Invalid request body",
+        details: validation.issues ?? [],
+      });
       return;
     }
 
     try {
+      const { image_url } = validation.value;
       const result = await scoreImage(image_url, config);
 
       stats.requests_success++;


### PR DESCRIPTION
### Motivation

- Ensure `POST /rate` only accepts a well-formed `image_url` to avoid runtime errors and malformed downstream requests.
- Centralize validation logic for maintainability and future extension by adding a reusable validator helper.

### Description

- Added `ValidationIssue` and `ValidationResult` types and a `MAX_IMAGE_URL_LENGTH` constant in `src/server.ts`.
- Implemented `validateRateRequest(body: unknown)` to check that the body is an object, `image_url` is a string, trimmed non-empty, does not exceed `2048` chars, parses as a `URL`, and uses only `http:` or `https:`.
- Updated the `/rate` handler to call `validateRateRequest`, return `400` with structured details `{ error, details }` when invalid, and use the validated `image_url` when calling `scoreImage`.

### Testing

- Ran `npm run build` to compile TypeScript and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05e484f708328b5f2064d404d6107)