### PR TITLE
Harden Anthropic structured output parsing and usage handling

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,6 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { Provider, type RatingResult } from "./base.js";
 
+type ParsedRating = {
+  rating: number;
+  justification: string;
+};
+
 export class AnthropicProvider extends Provider {
   readonly name = "anthropic";
   private client: Anthropic;
@@ -19,6 +24,29 @@ export class AnthropicProvider extends Provider {
       model,
       max_tokens: 1024,
       system: systemPrompt,
+      tool_choice: { type: "tool", name: "submit_rating" },
+      tools: [
+        {
+          name: "submit_rating",
+          description:
+            "Submit the final rating for the provided image as structured data.",
+          input_schema: {
+            type: "object",
+            properties: {
+              rating: {
+                type: "number",
+                minimum: 1,
+                maximum: 5,
+              },
+              justification: {
+                type: "string",
+              },
+            },
+            required: ["rating", "justification"],
+            additionalProperties: false,
+          },
+        },
+      ],
       messages: [
         {
           role: "user",
@@ -29,41 +57,130 @@ export class AnthropicProvider extends Provider {
             },
             {
               type: "text",
-              text: `Rate this image. Respond ONLY with valid JSON in this exact format:
-{"rating": <number 1.0-5.0 with one decimal>, "justification": "<brief explanation>"}`,
+              text: "Rate this image and call submit_rating with your final answer.",
             },
           ],
         },
       ],
     });
 
-    const textBlock = response.content.find((b) => b.type === "text");
-    if (!textBlock || textBlock.type !== "text") {
-      throw new Error("No text response from Anthropic");
-    }
+    const toolUseBlock = response.content.find((block): block is Anthropic.Messages.ToolUseBlock =>
+      block.type === "tool_use" && block.name === "submit_rating"
+    );
 
-    const jsonMatch = textBlock.text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      throw new Error(
-        `Failed to parse JSON from response: ${textBlock.text}`
-      );
-    }
+    const parsed = toolUseBlock
+      ? this.validateParsedShape(toolUseBlock.input)
+      : this.parseFromTextFallback(response.content);
 
-    const parsed = JSON.parse(jsonMatch[0]) as {
-      rating: number;
-      justification: string;
-    };
+    const usage = this.extractTokenUsage(response.usage);
 
     return {
       rating: this.validateRating(parsed.rating),
       justification: parsed.justification,
-      tokens_used: {
-        input: response.usage.input_tokens,
-        output: response.usage.output_tokens,
-        total: response.usage.input_tokens + response.usage.output_tokens,
-      },
+      tokens_used: usage,
       model: response.model,
       provider: this.name,
     };
+  }
+
+  private parseFromTextFallback(content: Anthropic.Messages.ContentBlock[]): ParsedRating {
+    const textBlock = content.find((block) => block.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      throw new Error(
+        "Anthropic response did not include submit_rating tool output or text fallback content."
+      );
+    }
+
+    const preview = this.safePreview(textBlock.text);
+    const rawJson = this.extractJsonObjectDeterministically(textBlock.text);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to parse Anthropic text fallback as JSON (${message}). Preview: ${preview}`
+      );
+    }
+
+    return this.validateParsedShape(parsed, preview);
+  }
+
+  private extractJsonObjectDeterministically(text: string): string {
+    const fencedMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fencedMatch?.[1]) {
+      return fencedMatch[1].trim();
+    }
+
+    const start = text.indexOf("{");
+    if (start === -1) {
+      throw new Error(
+        `Could not find JSON object start in Anthropic response. Preview: ${this.safePreview(text)}`
+      );
+    }
+
+    let depth = 0;
+    for (let i = start; i < text.length; i += 1) {
+      const char = text[i];
+      if (char === "{") {
+        depth += 1;
+      } else if (char === "}") {
+        depth -= 1;
+      }
+
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+
+    throw new Error(
+      `Could not find complete JSON object in Anthropic response. Preview: ${this.safePreview(text)}`
+    );
+  }
+
+  private validateParsedShape(parsed: unknown, preview = ""): ParsedRating {
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error(
+        `Parsed Anthropic rating payload was not an object.${preview ? ` Preview: ${preview}` : ""}`
+      );
+    }
+
+    const candidate = parsed as Record<string, unknown>;
+    if (typeof candidate.rating !== "number" || Number.isNaN(candidate.rating)) {
+      throw new Error(
+        `Parsed Anthropic rating payload had invalid rating (expected number).${preview ? ` Preview: ${preview}` : ""}`
+      );
+    }
+
+    if (typeof candidate.justification !== "string") {
+      throw new Error(
+        `Parsed Anthropic rating payload had invalid justification (expected string).${preview ? ` Preview: ${preview}` : ""}`
+      );
+    }
+
+    return {
+      rating: candidate.rating,
+      justification: candidate.justification,
+    };
+  }
+
+  private extractTokenUsage(usage: Anthropic.Messages.Usage | undefined): {
+    input: number;
+    output: number;
+    total: number;
+  } {
+    const input = typeof usage?.input_tokens === "number" ? usage.input_tokens : 0;
+    const output = typeof usage?.output_tokens === "number" ? usage.output_tokens : 0;
+
+    return {
+      input,
+      output,
+      total: input + output,
+    };
+  }
+
+  private safePreview(text: string): string {
+    return text.replace(/\s+/g, " ").slice(0, 200);
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce fragile regex-based parsing by requesting structured tool output from Anthropic when available. 
- Provide a deterministic, guarded fallback path for text responses to avoid runtime JSON parsing surprises. 
- Ensure parsed payloads are validated before use so downstream code receives well-typed values. 
- Defensively handle missing or malformed token usage fields to avoid runtime exceptions.

### Description
- Request structured output by invoking a `submit_rating` tool via `tool_choice` and providing an explicit `input_schema` with `rating` and `justification` fields. 
- Prefer `tool_use` blocks when present using a type guard `(block): block is Anthropic.Messages.ToolUseBlock` and validate the tool input shape via `validateParsedShape`. 
- Add a deterministic text fallback parser that extracts fenced JSON or uses brace-depth matching, wraps `JSON.parse` in `try/catch`, and surfaces actionable errors with a safe preview via `safePreview`. 
- Add strict runtime validation of the parsed object ensuring `rating` is a number and `justification` is a string, and add `extractTokenUsage` to safely read `response.usage` with numeric fallbacks while preserving `Provider.validateRating` clamping.

### Testing
- Ran the TypeScript build with `npm run build`, and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05e53cb388328a0950628bf2fad26)