### PR TITLE
Enforce signing key at startup and validate verification algorithm

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,10 @@
 import { readFileSync, existsSync, copyFileSync } from "node:fs";
 import { resolve } from "node:path";
 import yaml from "js-yaml";
+import {
+  ALLOWED_VERIFICATION_ALGORITHMS,
+  isAllowedVerificationAlgorithm,
+} from "./verification.js";
 
 export interface PersonaConfig {
   name: string;
@@ -73,6 +77,13 @@ export function loadConfig(dir: string = process.cwd()): AgentConfig {
   }
   if (!config.persona?.system_prompt) {
     throw new Error("Config missing required field: persona.system_prompt");
+  }
+  if (!isAllowedVerificationAlgorithm(config.verification?.algorithm)) {
+    throw new Error(
+      `Config verification.algorithm must be one of: ${ALLOWED_VERIFICATION_ALGORITHMS.join(
+        ", "
+      )}`
+    );
   }
 
   return config;

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,13 @@ export function createServer(config: AgentConfig) {
 }
 
 export function startServer(config: AgentConfig): void {
+  const signingKey = process.env.JOULEGRAM_SIGNING_KEY;
+  if (config.verification.sign_responses && !signingKey) {
+    throw new Error(
+      "Verification signing is enabled (verification.sign_responses=true), but JOULEGRAM_SIGNING_KEY is not set."
+    );
+  }
+
   const app = createServer(config);
   const { port, host } = config.server;
 

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,6 +1,16 @@
 import { createHmac, randomUUID } from "node:crypto";
 import type { VerificationConfig } from "./config.js";
 
+export const ALLOWED_VERIFICATION_ALGORITHMS = ["sha256", "sha512"] as const;
+
+export function isAllowedVerificationAlgorithm(
+  algorithm: string
+): algorithm is (typeof ALLOWED_VERIFICATION_ALGORITHMS)[number] {
+  return ALLOWED_VERIFICATION_ALGORITHMS.includes(
+    algorithm as (typeof ALLOWED_VERIFICATION_ALGORITHMS)[number]
+  );
+}
+
 export interface SignedResponse<T> {
   data: T;
   metadata: {


### PR DESCRIPTION
### Motivation
- Fail fast when response signing is enabled but the signing key is not provided to avoid unsigned responses at runtime. 
- Prevent runtime surprises by validating `verification.algorithm` against a small allowlist. 
- Centralize allowed algorithms so other code can reuse the same policy.

### Description
- Add `ALLOWED_VERIFICATION_ALGORITHMS` and `isAllowedVerificationAlgorithm` to `src/verification.ts` and keep supported algorithms as `"sha256"` and `"sha512"`.
- Validate `verification.algorithm` in `loadConfig` in `src/config.ts` and throw a clear error listing allowed options if the algorithm is invalid.
- In `startServer` (`src/server.ts`) throw a clear error when `verification.sign_responses` is `true` but `JOULEGRAM_SIGNING_KEY` is not set so startup fails fast.

### Testing
- Ran a TypeScript build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05e604ef48328bbf8773d79fcadbc)